### PR TITLE
fix: vulnerability

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,7 @@
+import os
+
 #pass your tokens here 
-BOT_TOKEN ='6028947050:AAHQqySDT8zRIIgMgWBTYUaSs7YcN6q8hwg' # bot token from t.me/botfather
-API_ID = 9583161 #api id from telegram.org
-API_HASH = 'aecf9e2b7c655c4f916564ab6d598a73' #api hash from telegram.org
+BOT_TOKEN = os.getenv("BOT_TOKEN") # bot token from t.me/botfather
+API_ID = os.getenv("API_ID") #api id from telegram.org
+API_HASH = os.getenv("API_HASH") #api hash from telegram.org
     


### PR DESCRIPTION
bot token & api ids visible for visitors

set `API_ID`, `API_HASH` & `BOT_TOKEN` as environment key